### PR TITLE
Exact match takes precedence

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Description: Stage Runner is an R package that helps with parametrizing
     and executing linear sequences of actions, common in the various
     stages of data analysis: data import, munging, modeling, export,
     and visualization.
-Version: 0.5.1
+Version: 0.5.2
 Author: Robert Krzyzanowski <technoguyrob@gmail.com>
 Maintainer: Robert Krzyzanowski <technoguyrob@gmail.com>
 Authors@R: c(person("Robert", "Krzyzanowski",

--- a/R/normalize_stage_keys.R
+++ b/R/normalize_stage_keys.R
@@ -162,7 +162,10 @@ normalize_stage_key.character <- function(key, keys, stages, parent_key,
     stop("No stage with key '", paste0(parent_key, key[[1]]), "' found")
   }
 
-  key_index <- grepl(tolower(key[[1]]), tolower(names(stages)), fixed = TRUE)
+  key_index <- tolower(key[[1]]) == tolower(names(stages))
+  if (!any(key_index)) {
+    key_index <- grepl(tolower(key[[1]]), tolower(names(stages)))
+  }
 
   if (is.finite(suppressWarnings(tmp <- as.numeric(key[[1]]))) &&
       tmp > 0 && tmp <= length(stages)) {

--- a/man/stagerunner.Rd
+++ b/man/stagerunner.Rd
@@ -8,7 +8,7 @@
 \title{Stagerunners are parametrized sequences of linear execution.}
 \format{\preformatted{function (...)  
  - attr(*, "srcref")=Class 'srcref'  atomic [1:8] 82 3 82 41 3 41 82 82
-  .. ..- attr(*, "srcfile")=Classes 'srcfilecopy', 'srcfile' <environment: 0x7feac893f790> 
+  .. ..- attr(*, "srcfile")=Classes 'srcfilecopy', 'srcfile' <environment: 0x7fb9cbd3f8e0> 
  - attr(*, "class")= chr "stageRunner_"
 }}
 \usage{


### PR DESCRIPTION
@robertzk @peterhurford this is meant to address this issue: https://github.com/robertzk/stagerunner/issues/48

I tried your regex trick to get at the `model` stage with `run('model$')` or `run('del$')` to no avail because we have `grepl(..., fixed = TRUE)` here: https://github.com/robertzk/stagerunner/blob/master/R/normalize_stage_keys.R#L165

Here's a snippet I ran on both 0.5.0 and this branch:
```R
sr <- stagerunner$new(new.env(), list(
    "model"       = force
  , "model_card"  = force
  , "card_ashian" = force
  ))
  
sr$run()

sr$run('model', verbose = TRUE)
sr$run('del$', verbose = TRUE)
sr$run('card', verbose = TRUE)
sr$run('^card', verbose = TRUE)
sr$run('model_card', verbose = TRUE)
```

The output on 0.5.0:
```R
> sr$run('model', verbose = TRUE)
Error in normalize_stage_key.character(key = key, keys = rest_keys, stages = stages,  :
  Multiple stages with key 'model', found: model, model_card

> sr$run('del$', verbose = TRUE)
Error in normalize_stage_key.character(key = key, keys = rest_keys, stages = stages,  :
  No stage with key 'del$' found

> sr$run('card', verbose = TRUE)
Error in normalize_stage_key.character(key = key, keys = rest_keys, stages = stages,  :
  Multiple stages with key 'card', found: model_card, card_ashian

> sr$run('^card', verbose = TRUE)
Error in normalize_stage_key.character(key = key, keys = rest_keys, stages = stages,  :
  No stage with key '^card' found

> sr$run('model_card', verbose = TRUE)
Running 2. model_card...
```

The output on this branch:
```R
> sr$run('model', verbose = TRUE)
Running 1. model...

> sr$run('del$', verbose = TRUE)
Running 1. model...

> sr$run('card', verbose = TRUE)
Error in normalize_stage_key.character(key = key, keys = rest_keys, stages = stages,  :
  Multiple stages with key 'card', found: model_card, card_ashian

> sr$run('^card', verbose = TRUE)
Running 3. card_ashian...

> sr$run('model_card', verbose = TRUE)
Running 2. model_card...
```